### PR TITLE
fix TypeError: 'bool' object has no attribute '__getitem__'

### DIFF
--- a/sitetree/sitetreeapp.py
+++ b/sitetree/sitetreeapp.py
@@ -799,7 +799,10 @@ class SiteTree(object):
         if not self.current_app_is_admin():
             # We do not need i18n for a tree rendered in Admin dropdown.
             tree_alias = self.resolve_tree_i18n_alias(tree_alias)
-        return self.get_cache_entry('parents', tree_alias)[item]
+        entries = self.get_cache_entry('parents', tree_alias)
+        if entries == False:
+            return []
+        return entries[item]
 
     def update_has_children(self, tree_alias, tree_items, navigation_type, menu_name=None):
         """Updates 'has_children' attribute for tree items."""


### PR DESCRIPTION
  File "local/lib/python2.7/site-packages/sitetree/templatetags/sitetree.py", line 265, in render
    tree_items = sitetree.menu(self.tree_alias, self.tree_branches, context, self.menu_name, self.include_parent)

  File "local/lib/python2.7/site-packages/sitetree/sitetreeapp.py", line 710, in menu
    menu_items = self.update_has_children(tree_alias, menu_items, 'menu', menu_name)

  File "local/lib/python2.7/site-packages/sitetree/sitetreeapp.py", line 808, in update_has_children
    children = self.get_children(tree_alias, tree_item)

  File "local/lib/python2.7/site-packages/sitetree/sitetreeapp.py", line 802, in get_children
    return self.get_cache_entry('parents', tree_alias)[item]

TypeError: 'bool' object has no attribute '__getitem__'